### PR TITLE
Upgrade to Java 21 and Spring Boot 3.3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-ARG VARIANT=17-bullseye
+ARG VARIANT=21-bullseye
 FROM mcr.microsoft.com/vscode/devcontainers/java:${VARIANT}
 
 ARG NODE_VERSION="none"
@@ -8,6 +8,6 @@ ARG USER=vscode
 VOLUME /home/$USER/.m2
 VOLUME /home/$USER/.gradle
 
-ARG JAVA_VERSION=17.0.4.1-ms
+ARG JAVA_VERSION=21.0.3-ms
 RUN sudo mkdir /home/$USER/.m2 /home/$USER/.gradle && sudo chown $USER:$USER /home/$USER/.m2 /home/$USER/.gradle
 RUN bash -lc '. /usr/local/sdkman/bin/sdkman-init.sh && sdk install java $JAVA_VERSION && sdk use java $JAVA_VERSION'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-  id 'org.springframework.boot' version '3.0.1'
+  id 'org.springframework.boot' version '3.3.0'
   id 'io.spring.dependency-management' version '1.1.0'
   id 'java'
 }
@@ -8,7 +8,7 @@ apply plugin: 'java'
 
 group = 'org.springframework.samples'
 version = '3.0.0'
-sourceCompatibility = '17'
+sourceCompatibility = '21'
 
 repositories {
   mavenCentral()

--- a/pom.xml
+++ b/pom.xml
@@ -8,14 +8,14 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.0.2</version>
+    <version>3.3.0</version>
   </parent>
   <name>petclinic</name>
 
   <properties>
 
     <!-- Generic properties -->
-    <java.version>17</java.version>
+    <java.version>21</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 


### PR DESCRIPTION
Related to #1

Upgrades the application to Java 21 and Spring Boot 3.3.0, and updates the development container configuration.

- **Java and Spring Boot Version Upgrade**: Updates `build.gradle` and `pom.xml` to use Java 21 and Spring Boot 3.3.0. This aligns with the application lifecycle policies and leverages the latest features and improvements of these technologies.
- **Development Container Configuration**: Modifies `.devcontainer/Dockerfile` to use a base image for Java 21 (`21-bullseye`) and sets the `ARG JAVA_VERSION` to `21.0.3-ms`. This ensures the development environment is consistent with the application's Java version.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/octocademy/spring-petclinic/issues/1?shareId=420a4065-00d5-4bd5-9775-923c9334dc43).